### PR TITLE
Changes to generation of links.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ module.exports = {
         "page:before": function (page) {
             page.content = toc.insert(page.content, {
                 slugify: function (str) {
-                  return slug(str);
-                }
+                  return slug(str.replace(/&.*?;/g, ""));
+                },
+                bullets: "*"
             });
             if (this.options.pluginsConfig.atoc.addClass) {
                 var className = this.options.pluginsConfig.atoc.className || 'atoc';


### PR DESCRIPTION
TOCs with more than 3 levels are not created correctly. At the fourth level markdown-toc uses '~' at the beginning of the list item. This change uses a '*' for all links, which is creating a proper toc. 

Also all HTML entities (e.g. `&gt;`) are stripped from the links.
